### PR TITLE
Convert List<> to Array to avoid "Collection was modified..." errors

### DIFF
--- a/SharpCifs.Std/Smb/SmbTransport.cs
+++ b/SharpCifs.Std/Smb/SmbTransport.cs
@@ -97,7 +97,7 @@ namespace SharpCifs.Smb
             {
                 var failedTransport = new List<SmbTransport>();
 
-                foreach (var transport in SmbConstants.Connections)
+                foreach (var transport in SmbConstants.Connections.ToArray())
                 {
                     //強制破棄フラグONのとき、接続状態がどうであれ破棄する。
                     if (force)


### PR DESCRIPTION
When clearing cached connections, the current code attempts to modify a List<> while iterating over it. This will lead to intermittent "Collection was modified; enumeration operation may not execute." errors. By converting the List<> to an Array, the code may execute cleanly.